### PR TITLE
Update `generateAlias` method in `TravelDataContainer` to support `in…

### DIFF
--- a/src/DataContainer/TravelDataContainer.php
+++ b/src/DataContainer/TravelDataContainer.php
@@ -63,7 +63,7 @@ final readonly class TravelDataContainer
         $model->save();
     }
 
-    private function generateAlias(string $name, int $id): string
+    private function generateAlias(string $name, int|string $id): string
     {
         $alias = $this->slugGenerator->generate($name);
 


### PR DESCRIPTION
…t|string` type for `$id` parameter.