### PR TITLE
Update `generateTravelCode` in `DateDataContainer` to cast `$id` to `…

### DIFF
--- a/src/DataContainer/DateDataContainer.php
+++ b/src/DataContainer/DateDataContainer.php
@@ -33,9 +33,9 @@ final readonly class DateDataContainer
         return $this->generateTravelCode($dc->id);
     }
 
-    private function generateTravelCode(int $id): string
+    private function generateTravelCode(int|string $id): string
     {
-        return new Sqids('ABCDEFGHKLMNPRSTUVWXYZ23456789', minLength: 4)->encode([$id]);
+        return new Sqids('ABCDEFGHKLMNPRSTUVWXYZ23456789', minLength: 4)->encode([(int)$id]);
     }
 
 }


### PR DESCRIPTION
…int` and support `int|string` type